### PR TITLE
fix: change capability name to reflect `command-type-ov`

### DIFF
--- a/internal/capability/caldera/caldera.go
+++ b/internal/capability/caldera/caldera.go
@@ -13,9 +13,9 @@ type calderaCapability struct{}
 type Empty struct{}
 
 const (
-	calderaResult  = "__soarca_caldera_result__"
-	calderaError   = "__soarca_caldera_error__"
-	capabilityName = "soarca-caldera"
+	calderaResult  = "__soarca_caldera_cmd_result__"
+	calderaError   = "__soarca_caldera_cmd_error__"
+	capabilityName = "soarca-caldera-cmd"
 )
 
 var (


### PR DESCRIPTION
The capability name should come from the CACAO `command-type-ov`, which in the case of caldera is `caldera-cmd`.