### PR TITLE
SOARCA-184 make sure retry logic triggers another request

### DIFF
--- a/pkg/core/capability/caldera/caldera.go
+++ b/pkg/core/capability/caldera/caldera.go
@@ -124,7 +124,7 @@ func (c *calderaCapability) Execute(
 	}
 
 	// poll for operation status
-	for finished, err := connection.IsOperationFinished(operationId); true; {
+	for finished, err := connection.IsOperationFinished(operationId); true; finished, err = connection.IsOperationFinished(operationId) {
 		if err != nil {
 			log.Warn("Could not poll for operation status, retrying in 3 seconds")
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
The logs were lying, if there was an error, the retry loop was infinite (no further requests were made).