### PR TITLE
fix: not all env var names are consistent

### DIFF
--- a/deployments/docker/soarca/docker-compose.yml
+++ b/deployments/docker/soarca/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       THEHIVE_API_BASE_URL: http://localhost:9000/api/v1/
       CALDERA_HOST: "caldera"
       CALDERA_PORT: "8888"
-      CALDERA_API: "ADMIN123"
+      CALDERA_API_KEY: "ADMIN123"
     networks:
       - db-net
       - mqtt-net

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -122,7 +122,9 @@ ENABLE_FINS: false
 MQTT_BROKER: "localhost"
 MQTT_PORT: 1883
 
-CALDERA_URL: ""
+CALDERA_HOST: "http://caldera.mydomain.com"
+CALDERA_PORT: "8888"
+CALDERA_API_KEY: "ADMIN123"
 
 HTTP_SKIP_CERT_VALIDATION: false
 {{< /tab >}}

--- a/docs/content/en/docs/installation-configuration/_index.md
+++ b/docs/content/en/docs/installation-configuration/_index.md
@@ -52,6 +52,16 @@ After completing the [Getting Started](/docs/getting-started/_index.md) setup fo
 
 -----
 
+#### Caldera
+
+| Variable        | Content                                | Description                                                                 |
+|-----------------|----------------------------------------|-----------------------------------------------------------------------------|
+| CALDERA_HOST    | `http://your.caldera.instance`         | Set the base URL for the Caldera API. Must be set to use the integration.   |
+| CALDERA_PORT    | `8888`                                 | Set the port for the Caldera instance. Must be set to use the integration.  |
+| CALDERA_API_KEY | `your_token`                           | Set the base URL for The Hive API. Must be set to use the integration.      |
+
+-----
+
 ### Authentication
 
 {{% alert title="Note" color="primary" %}}


### PR DESCRIPTION
I changed all occurrences of the env vars starting with `CALDERA_` to be one of these three:
- `CALDERA_HOST`
- `CALDERA_PORT`
- `CALDERA_API_KEY`